### PR TITLE
Add pytest tests with runner

### DIFF
--- a/run_tests.sh
+++ b/run_tests.sh
@@ -1,0 +1,2 @@
+#!/bin/bash
+pytest -q

--- a/tests/test_link_converter.py
+++ b/tests/test_link_converter.py
@@ -1,0 +1,24 @@
+import importlib.util
+import pathlib
+
+spec = importlib.util.spec_from_file_location('link_converter', pathlib.Path(__file__).parent.parent / 'doc-tool' / 'link_converter.py')
+link_converter = importlib.util.module_from_spec(spec)
+spec.loader.exec_module(link_converter)
+
+
+def test_replace_links_in_markdown(monkeypatch, tmp_path):
+    md = tmp_path / 'test.md'
+    md.write_text('See https://example.com/docs/page1 and https://bad.com/invalid. Also see /guide/intro')
+
+    def fake_is_url_valid(url):
+        return 'example.com' in url
+
+    monkeypatch.setattr(link_converter, 'is_url_valid', fake_is_url_valid)
+
+    link_converter.replace_links_in_markdown(str(tmp_path))
+
+    content = md.read_text()
+    assert '[[docs/page1]]' in content
+    assert 'https://bad.com/invalid' in content
+    assert '[[guide/intro]]' in content
+

--- a/tests/test_sitemap.py
+++ b/tests/test_sitemap.py
@@ -1,0 +1,33 @@
+import importlib.util
+import pathlib
+from types import SimpleNamespace
+
+spec = importlib.util.spec_from_file_location('sitemap', pathlib.Path(__file__).parent.parent / 'doc-tool' / 'sitemap.py')
+sitemap = importlib.util.module_from_spec(spec)
+spec.loader.exec_module(sitemap)
+
+
+def test_sitemap_crawl(monkeypatch):
+    html_pages = {
+        'http://example.com': '<a href="/about">About</a><a href="http://external.com">Ext</a>',
+        'http://example.com/about': '<p>No links</p>'
+    }
+
+    class MockResponse:
+        def __init__(self, url):
+            self.text = html_pages[url]
+            self.status_code = 200
+        def raise_for_status(self):
+            pass
+
+    def mock_get(url, timeout=10, headers=None):
+        return MockResponse(url)
+
+    monkeypatch.setattr(sitemap.requests, 'get', mock_get)
+    monkeypatch.setattr(sitemap.time, 'sleep', lambda x: None)
+
+    builder = sitemap.SitemapBuilder('http://example.com')
+    builder.crawl()
+
+    assert sorted(builder.urls) == ['http://example.com', 'http://example.com/about']
+

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -1,0 +1,12 @@
+import importlib.util
+import pathlib
+
+spec = importlib.util.spec_from_file_location('utils', pathlib.Path(__file__).parent.parent / 'doc-tool' / 'utils.py')
+utils = importlib.util.module_from_spec(spec)
+spec.loader.exec_module(utils)
+
+def test_domain_to_folder_simple():
+    assert utils.domain_to_folder('https://example.com/docs') == 'example_com'
+
+def test_domain_to_folder_subdomain():
+    assert utils.domain_to_folder('http://sub.domain.co.uk/') == 'sub_domain_co_uk'


### PR DESCRIPTION
## Summary
- add `tests/` directory with pytest-based tests
- mock out network calls for sitemap and link conversion tests
- add `run_tests.sh` for running the test suite

## Testing
- `./run_tests.sh`

------
https://chatgpt.com/codex/tasks/task_e_684e0fe74b0883268fb4ee34363da2d6