### PR TITLE
Add configurable export formats

### DIFF
--- a/doc-tool/format_converter.py
+++ b/doc-tool/format_converter.py
@@ -1,0 +1,54 @@
+import os
+import sys
+
+try:
+    import markdown
+except ImportError:
+    markdown = None
+
+try:
+    import pypandoc
+except ImportError:
+    pypandoc = None
+
+def convert_markdown_to_html(md_path, html_path):
+    if not markdown:
+        print("markdown package not available; cannot convert to HTML")
+        return
+    with open(md_path, 'r', encoding='utf-8') as f:
+        text = f.read()
+    html = markdown.markdown(text)
+    with open(html_path, 'w', encoding='utf-8') as f:
+        f.write(html)
+
+
+def convert_markdown_to_rtf(md_path, rtf_path):
+    if not pypandoc:
+        print("pypandoc not available; skipping RTF conversion for", md_path)
+        return
+    pypandoc.convert_file(md_path, 'rtf', outputfile=rtf_path)
+
+
+def convert_output(folder, output_format):
+    for root, _, files in os.walk(folder):
+        for file in files:
+            if not file.endswith('.md'):
+                continue
+            md_path = os.path.join(root, file)
+            base = md_path[:-3]
+            if output_format == 'md+rtf':
+                rtf_path = base + '.rtf'
+                convert_markdown_to_rtf(md_path, rtf_path)
+            elif output_format == 'html':
+                html_path = base + '.html'
+                convert_markdown_to_html(md_path, html_path)
+                os.remove(md_path)
+
+
+if __name__ == '__main__':
+    if len(sys.argv) != 3:
+        print('Usage: python format_converter.py <folder> <format>')
+        sys.exit(1)
+    folder = sys.argv[1]
+    output_format = sys.argv[2]
+    convert_output(folder, output_format)

--- a/doc-tool/main.py
+++ b/doc-tool/main.py
@@ -20,6 +20,21 @@ def prompt_mode():
         sys.exit(1)
     return choice
 
+def prompt_output_format():
+    print("Choose output format:")
+    print("1. Markdown (.md)")
+    print("2. Markdown + RTF (.md + .rtf)")
+    print("3. HTML")
+    choice = input("Enter 1, 2, or 3: ").strip()
+    if choice == '1':
+        return 'md'
+    if choice == '2':
+        return 'md+rtf'
+    if choice == '3':
+        return 'html'
+    print("Invalid choice. Exiting.")
+    sys.exit(1)
+
 if __name__ == "__main__":
     mode = prompt_mode()
     if mode == '2':
@@ -30,12 +45,16 @@ if __name__ == "__main__":
         print("Invalid URL, must start with http or https")
         sys.exit(1)
 
+    output_format = prompt_output_format()
+
     output_folder = domain_to_folder(root_url)
     os.makedirs(output_folder, exist_ok=True)
 
     run_step("sitemap.py", [root_url, output_folder])
     run_step("scraper.py", [os.path.join(output_folder, "urls.txt"), output_folder])
-    run_step("link_converter.py", [output_folder])
+    run_step("link_converter.py", [output_folder, "--format", output_format])
     run_step("cleaner.py", [output_folder])
+    if output_format != 'md':
+        run_step("format_converter.py", [output_folder, output_format])
 
     print("\nAll steps completed.")

--- a/tests/test_format_converter.py
+++ b/tests/test_format_converter.py
@@ -1,0 +1,17 @@
+import importlib.util
+import pathlib
+
+spec = importlib.util.spec_from_file_location('format_converter', pathlib.Path(__file__).parent.parent / 'doc-tool' / 'format_converter.py')
+format_converter = importlib.util.module_from_spec(spec)
+spec.loader.exec_module(format_converter)
+
+
+def test_convert_output_html(tmp_path):
+    md = tmp_path / 'file.md'
+    md.write_text('# Title\n\nSome text', encoding='utf-8')
+    format_converter.convert_output(str(tmp_path), 'html')
+    html = tmp_path / 'file.html'
+    assert html.exists()
+    assert '<h1>Title' in html.read_text(encoding='utf-8')
+    assert not md.exists()
+


### PR DESCRIPTION
## Summary
- support selecting MD, MD+RTF, or HTML output in `main.py`
- adapt link conversion and backlink generation based on output format
- add new `format_converter.py` to handle RTF/HTML conversion
- test HTML conversion

## Testing
- `./run_tests.sh`

------
https://chatgpt.com/codex/tasks/task_e_684e10d1afc88326ab03a85e4df688e8